### PR TITLE
Fix for can't find Windows directory

### DIFF
--- a/darkSlack.sh
+++ b/darkSlack.sh
@@ -41,7 +41,7 @@ if [[ -z $SLACK_RESOURCES_DIR ]]; then
   # Assume on windows if the linux and osx paths failed.
   # Get Windows environment info:
   WIN_HOME_RAW="$(cmd.exe /c "<nul set /p=%UserProfile%" 2>/dev/null)"
-  USERPROFILE_DRIVE="${WIN_HOME_RAW%%:*}:"
+  USERPROFILE_DRIVE="${WIN_HOME_RAW%%:*}:\\"
   USERPROFILE_MNT="$(findmnt --noheadings --first-only --output TARGET "$USERPROFILE_DRIVE")"
   USERPROFILE_DIR="${WIN_HOME_RAW#*:}"
   WIN_HOME="${USERPROFILE_MNT}${USERPROFILE_DIR//\\//}"


### PR DESCRIPTION
The mount point description is C:\, but the script was written to just look for C: only.  I added the backslash, now it works.  If this breaks someone else, then we need to adjust the script to look for both descriptors and read the correct one.